### PR TITLE
exhaust the player on craft all if the stamina mod is installed

### DIFF
--- a/depends.txt
+++ b/depends.txt
@@ -1,2 +1,2 @@
-
 unified_inventory
+stamina?

--- a/mod.conf
+++ b/mod.conf
@@ -1,1 +1,2 @@
 name = unified_inventory_plus
+optional_depends = stamina


### PR DESCRIPTION
I've been holding off installing this awesome mod on the Blocky Survival server because the "craft all" button bypasses the stamina penalty when crafting stuff. This simple update checks to see if stamina is installed and a recent version, and if so, exhausts the player when crafting.