### PR TITLE
craft all: properly invoke on_crafted callbacks

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -7,6 +7,7 @@ globals = {
 }
 
 read_globals = {
+	"futil",
 	"stamina",
 	"skyblock",
 	"ItemStack",

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,19 @@
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v3.3.0
+    hooks:
+      - id: fix-byte-order-marker
+      - id: end-of-file-fixer
+      - id: trailing-whitespace
+      - id: mixed-line-ending
+        args: [ --fix=lf ]
+
+  - repo: local
+    hooks:
+      - id: luacheck
+        name: luacheck
+        language: system
+        entry: luacheck
+        pass_filenames: true
+        types: [ file, lua ]
+        args: [ -q ]

--- a/craft_all.lua
+++ b/craft_all.lua
@@ -95,6 +95,8 @@ local function craft_craftall(player)
         tmp_inv:set_list("craft", decremented_input.items)
 
         -- invoke callbacks, for compatibility w/ stamina, skyblock, moretrees, etc.
+        -- note that this is an *undocumented* handler of the minetest lua API, and possibly is subject to change
+        -- in the future.
         output.item = minetest.on_craft(output.item, player, craft_list, tmp_inv)
 
         -- track items added to the inventory, in case we need to remove them later

--- a/init.lua
+++ b/init.lua
@@ -1,4 +1,5 @@
--- Unified Inventory Plus for Minetest 0.4.8+
+-- Unified Inventory Plus for Minetest
+futil.check_version({ year = 2023, month = 02, day = 26 })
 
 local modname = minetest.get_current_modname()
 local modpath = minetest.get_modpath(modname)
@@ -27,7 +28,6 @@ unified_inventory_plus = {
 
     has = {
         stamina = minetest.global_exists("stamina"),
-        skyblock = minetest.get_modpath("skyblock"),
     },
 
     log = function(level, message_fmt, ...)

--- a/mod.conf
+++ b/mod.conf
@@ -1,4 +1,4 @@
 name = unified_inventory_plus
-depends = unified_inventory
-optional_depends = stamina, skyblock
+depends = unified_inventory, futil
+optional_depends = stamina
 min_minetest_version = 5.4.0

--- a/settingtypes.txt
+++ b/settingtypes.txt
@@ -4,4 +4,5 @@ unified_inventory_plus.enable_craft_rotate (enable rotate buttons) bool true
 unified_inventory_plus.enable_craft_clear (enable "clear" button) bool true
 
 # Disable the "craft all" feature if saturation (from the stamina mod) is below a given value.
-unified_inventory_plus.craft_all_min_saturation (Minimum saturation for "craft all") int 1 0 20
+# Set to -1 always allow "craft all".
+unified_inventory_plus.craft_all_min_saturation (Minimum saturation for "craft all") int 1 -1 20


### PR DESCRIPTION
a player reported that crafting coconut milk from moretrees using the "craft all" button resulted in the axe in the recipe being lost, instead of being worn down.

![image](https://user-images.githubusercontent.com/25628292/221434946-a484ad18-872e-4e53-8da9-6cd987a0f9f4.png)

this is because the "wearing" of the tool is handled via a `minetest.register_on_craft` callback, and uip doesn't invoke those callbacks. the correct behavior, it seems, is to invoke `core.on_craft`, which isn't documented, but which is how the engine invokes those callbacks. 

an upside of using this handler is that we no longer have to explicitly call the stamina/skyblock `on_craft` code, and we're probably now compatible w/ a number of other mods as well. 

while i was updating the code, i also switched from using a detached inventory to a `FakeInventory` from my [futil](https://content.minetest.net/packages/rheo/futil/) mod. this is because every modification of a detached inventory is sent to the player, even if the inventory is destroyed before the player can interact w/ it. basically, it cuts down on the number of packets sent to a player, which can be noticeable when working w/ very large stacks. 