### PR TITLE
improve craft logging

### DIFF
--- a/craft_all.lua
+++ b/craft_all.lua
@@ -42,7 +42,7 @@ local function infer_width(list, expected)
         end
     end
     if not width then
-        uip.log("warning", S("Can't infer recipe width for %s"), expected:to_string())
+        uip.log("warning", "Can't infer recipe width for %s", expected:to_string())
     end
     return width
 end
@@ -139,7 +139,7 @@ local function craft_craftall(player)
     player_inv:set_list("craft", craft_list)
     player_inv:set_list("main", tmp_inv:get_list("main"))
 
-    uip.log("action", S("%s crafts %s %i"), player_name, expected_result:to_string(), num_crafted)
+    uip.log("action", "player %s crafts %s %i", player_name, expected_result:to_string(), num_crafted)
 end
 
 minetest.register_on_player_receive_fields(function(player, formname, fields)

--- a/init.lua
+++ b/init.lua
@@ -31,7 +31,7 @@ unified_inventory_plus = {
     },
 
     log = function(level, message_fmt, ...)
-        minetest.log(level, "[unified_inventory_plus]" .. message_fmt:format(...))
+        minetest.log(level, "[unified_inventory_plus] " .. message_fmt:format(...))
     end,
 
     S = minetest.get_translator("unified_inventory"),


### PR DESCRIPTION
I consider the translating of log messages extremely unnecessary

old behavior:
![grafik](https://github.com/mt-mods/unified_inventory_plus/assets/89982526/9a1d74b8-ee43-4f5e-a382-b6d63b79e1f0)

new behavior:
![grafik](https://github.com/mt-mods/unified_inventory_plus/assets/89982526/359c528c-0cad-486e-bcbb-d8faba5e43ca)
